### PR TITLE
Add fade transition between routes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,7 +7,9 @@ import Sidebar from './components/Sidebar.vue'
   <v-app>
     <Sidebar />
     <v-main class="content">
-      <RouterView />
+      <transition name="fade" mode="out-in">
+        <RouterView />
+      </transition>
     </v-main>
   </v-app>
 </template>

--- a/src/style.css
+++ b/src/style.css
@@ -32,3 +32,14 @@ body {
     color: #747bff;
   }
 }
+
+/* Route transition */
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 300ms ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}


### PR DESCRIPTION
## Summary
- Wrap the router view in a Vue `<transition>` with `mode="out-in"` to cross-fade between pages
- Define `.fade-*` CSS classes for a subtle 300ms opacity transition

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a106e2985c8327a6432739976ccf2f