### PR TITLE
chore: simplify sidebar styling

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -2,7 +2,7 @@
 </script>
 
 <template>
-  <v-navigation-drawer permanent>
+  <v-navigation-drawer permanent class="sidebar" elevation="0">
     <v-list>
       <v-list-item title="My Site" class="text-h6"></v-list-item>
       <v-list-item to="/" title="Home"></v-list-item>
@@ -16,4 +16,22 @@
 </template>
 
 <style scoped>
+
+.sidebar {
+  background-color: #f9f9f9;
+  border: none;
+  font-weight: 300;
+}
+
+.sidebar :deep(.v-list-item) {
+  margin: 0.25rem 0;
+  padding: 0.25rem 0.5rem;
+  font-weight: 300;
+  background: transparent;
+}
+
+.sidebar :deep(.v-list-item:hover) {
+  background-color: rgba(0, 0, 0, 0.04);
+}
+
 </style>


### PR DESCRIPTION
## Summary
- remove default Vuetify backgrounds and borders from sidebar
- add thin font, light background, and subtle hover styles

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a106e1a8288327b21641f295366718