### PR TITLE
feat: add hero section to home page

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,17 +1,38 @@
 <template>
-  <div class="home">
-    <h1 class="title">Welcome to My Website</h1>
-    <p>Explore the sidebar to learn more.</p>
-  </div>
+  <section
+    class="hero"
+    :style="{ backgroundImage: imageUrl ? `url(${imageUrl})` : undefined }"
+  >
+    <div class="home">
+      <h1 class="title">Welcome to My Website</h1>
+      <p>{{ tagline }}</p>
+    </div>
+  </section>
 </template>
 
+<script setup>
+const { imageUrl, tagline } = defineProps({
+  imageUrl: {
+    type: String,
+    default: "",
+  },
+  tagline: {
+    type: String,
+    default: "Explore the sidebar to learn more.",
+  },
+});
+</script>
+
 <style scoped>
-.home {
+.hero {
+  min-height: 100vh;
   display: flex;
-  flex-direction: column;
   justify-content: center;
   align-items: center;
-  height: 100%;
+  background-size: cover;
+  background-position: center;
+}
+.home {
   text-align: center;
 }
 .title {


### PR DESCRIPTION
## Summary
- wrap home view content in a hero section
- add hero styles for full-height background and centered text
- expose props for tagline and background image URL

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a106e0f6e08327bc2ea9b540a30bee