### PR TITLE
Switch to light theme with neutral typography

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -2,9 +2,8 @@
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color: #1a1a1a;
+  background-color: #ffffff;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -12,23 +11,14 @@
 }
 
 a {
-  color: #646cff;
+  color: #1a1a1a;
   text-decoration: none;
 }
 a:hover {
-  color: #535bf2;
+  color: #555555;
 }
 
 body {
   margin: 0;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
+  color: #1a1a1a;
 }


### PR DESCRIPTION
## Summary
- replace dark default in `:root` with light background and dark text
- remove automatic color-scheme switching
- apply black/gray typography for body text and links

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a106dfb60c8327a31bc21c9de5a43a