### PR TITLE
feat: arrange About page in grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,13 @@
 <!doctype html>
 <html lang="en">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400..900;1,400..900&display=swap" rel="stylesheet">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Andrew Jenkin Sculpture</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400..900;1,400..900&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="app"></div>

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -1,15 +1,24 @@
 <template>
   <div class="page container fade-up">
-    <h1>About Me</h1>
-    <h2>Andrew Jenkin</h2>
-    <p>I am an artist primarily occupied with physical sculptural work and have been constructing and fabricating for many years, due to my background in engineering. This has instilled me with many practical skills that I now apply in a more creative capacity. 
-      I choose to work in a wide range of mediums to maximise a diverse variety of works, and I have a vast knowledge of the best applications of materials for designs.
-      My recent work draws heavily on Geometry and Mathematics. Particularly Polygons, Polyhedra and sacred geometry, all of which have complex mathematical connotations. 
-      Having spent many years constructing objects from plans, patterns and templates, I have developed a passion of applying these processes to my own creative endeavours.
-      Over the last two years of my formal art training I have spent time with the much-acclaimed art sculptor Charles Hadcock, assisting him in his studio allowed me a privileged insight in the practice of a professional sculptor.
-      Which has served to give me a desire to create larger scale works and a thirst to acquire commissions for public art sculpture.</p>
+    <div class="about-grid">
+      <img class="about-image" :src="aboutPic" alt="Andrew Jenkin" />
+      <div class="about-text">
+        <h1>About Me</h1>
+        <h2>Andrew Jenkin</h2>
+        <p>I am an artist primarily occupied with physical sculptural work and have been constructing and fabricating for many years, due to my background in engineering. This has instilled me with many practical skills that I now apply in a more creative capacity.
+          I choose to work in a wide range of mediums to maximise a diverse variety of works, and I have a vast knowledge of the best applications of materials for designs.
+          My recent work draws heavily on Geometry and Mathematics. Particularly Polygons, Polyhedra and sacred geometry, all of which have complex mathematical connotations.
+          Having spent many years constructing objects from plans, patterns and templates, I have developed a passion of applying these processes to my own creative endeavours.
+          Over the last two years of my formal art training I have spent time with the much-acclaimed art sculptor Charles Hadcock, assisting him in his studio allowed me a privileged insight in the practice of a professional sculptor.
+          Which has served to give me a desire to create larger scale works and a thirst to acquire commissions for public art sculpture.</p>
+      </div>
+    </div>
   </div>
 </template>
+
+<script setup>
+import aboutPic from '../assets/About/AboutPic.jpg'
+</script>
 
 <style scoped>
 .page {
@@ -18,5 +27,16 @@
   font-optical-sizing: auto;
   font-weight: <weight>;
   font-style: normal;
+}
+
+.about-grid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 1rem;
+  align-items: flex-start;
+}
+
+.about-image {
+  max-width: 300px;
 }
 </style>


### PR DESCRIPTION
## Summary
- arrange About page content in a two-column grid
- fix index.html by moving font links inside the head

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a1bbea817c8327bd770465ff48613d