### PR TITLE
feat: use video background player on home page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@mdi/font": "^7.4.47",
         "vue": "^3.5.18",
+        "vue-responsive-video-background-player": "^2.4.1",
         "vue-router": "^4.5.1",
         "vuetify": "^3.9.5"
       },
@@ -1293,6 +1294,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vue-responsive-video-background-player": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/vue-responsive-video-background-player/-/vue-responsive-video-background-player-2.4.1.tgz",
+      "integrity": "sha512-uy3WHYGuuChreWFybprXTkKkeESdUtaZoSbIPJIwcQPx5VOrt3igPY2o8sYqHsfz//hFGMzCBX0uHH8Lp+Yfmw==",
+      "license": "MIT"
     },
     "node_modules/vue-router": {
       "version": "4.5.1",

--- a/package.json
+++ b/package.json
@@ -8,15 +8,16 @@
     "build": "vite build",
     "preview": "vite preview"
   },
-    "dependencies": {
-      "@mdi/font": "^7.4.47",
-      "vue": "^3.5.18",
-      "vue-router": "^4.5.1",
-      "vuetify": "^3.9.5"
-    },
-    "devDependencies": {
-      "@vitejs/plugin-vue": "^6.0.1",
-      "vite": "^7.1.2",
-      "vite-plugin-vuetify": "^2.1.2"
-    }
+  "dependencies": {
+    "@mdi/font": "^7.4.47",
+    "vue": "^3.5.18",
+    "vue-responsive-video-background-player": "^2.4.1",
+    "vue-router": "^4.5.1",
+    "vuetify": "^3.9.5"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^6.0.1",
+    "vite": "^7.1.2",
+    "vite-plugin-vuetify": "^2.1.2"
   }
+}

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,21 +1,19 @@
 <template>
   <section class="hero">
-    <video
-      class="background-video"
-      autoplay
-      muted
-      loop
-      playsinline
+    <video-background
       :src="backgroundVideo"
-    ></video>
-    <div class="home fade-up">
-      <h1 class="title">Andrew Jenkin Sculpture</h1>
-      <p>{{ tagline }}</p>
-    </div>
+      style="height: 100vh;"
+    >
+      <div class="home fade-up">
+        <h1 class="title">Andrew Jenkin Sculpture</h1>
+        <p>{{ tagline }}</p>
+      </div>
+    </video-background>
   </section>
 </template>
 
 <script setup>
+import VideoBackground from "vue-responsive-video-background-player";
 import backgroundVideo from "../assets/Video/A Certain Ratio.mp4";
 
 const { tagline } = defineProps({
@@ -54,15 +52,5 @@ const { tagline } = defineProps({
   font-optical-sizing: auto;
   font-weight: <weight>;
   font-style: normal;
-}
-
-.background-video {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  z-index: -1;
 }
 </style>


### PR DESCRIPTION
## Summary
- use `vue-responsive-video-background-player` for the home page hero
- add package dependency

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a1d9dc077083279e4f2646cc849063