### PR TITLE
Improve mobile navigation layout

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -1,17 +1,35 @@
 <script setup>
-import { computed } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
+import { useDisplay } from 'vuetify'
 
 const route = useRoute()
 const isHome = computed(() => route.path === '/')
+
+const { mdAndDown } = useDisplay()
+const drawer = ref(!mdAndDown.value)
+watch(mdAndDown, val => { drawer.value = !val })
 </script>
 
 <template>
+  <v-app-bar
+    v-if="mdAndDown"
+    flat
+    class="mobile-bar"
+    :class="{ 'home-nav': isHome }"
+    app
+  >
+    <v-app-bar-nav-icon @click="drawer = !drawer" />
+    <v-toolbar-title>Andrew Jenkin Sculpture</v-toolbar-title>
+  </v-app-bar>
   <v-navigation-drawer
-    permanent
+    v-model="drawer"
+    :permanent="!mdAndDown"
+    :temporary="mdAndDown"
     class="sidebar"
     elevation="0"
     :class="{ 'home-nav': isHome }"
+    app
   >
     <v-list>
       <v-list-item title="Andrew Jenkin Sculpture" class="text-h3" style="font-size: 1.2rem;"></v-list-item>
@@ -39,13 +57,20 @@ font-size: 1.2rem;
   font-style: normal;
 }
 
+.mobile-bar {
+  background-color: #f9f9f9;
+  font-family: "Playfair Display", serif;
+}
+
 .home-nav {
   background-color: #000 !important;
   color: #fff !important;
 }
 
 .home-nav :deep(.v-list-item-title),
-.home-nav :deep(.v-list-item) {
+.home-nav :deep(.v-list-item),
+.home-nav :deep(.v-toolbar-title),
+.home-nav :deep(.v-btn) {
   color: #fff !important;
 }
 

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -41,4 +41,26 @@ import aboutPic from '../assets/About/AboutPic.jpg'
 .about-image {
   max-width: 500px;
 }
+
+@media (max-width: 600px) {
+  .page {
+    margin-left: 0;
+    padding: 1rem;
+  }
+
+  .about-grid {
+    grid-template-columns: 1fr;
+    row-gap: 1.5rem;
+    text-align: center;
+  }
+
+  .about-image {
+    max-width: 100%;
+    margin: 0 auto;
+  }
+
+  .about-text {
+    text-align: left;
+  }
+}
 </style>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -8,7 +8,7 @@
       <div class="home fade-up">
         <h1 class="title">Andrew Jenkin Sculpture</h1>
         <p>{{ tagline }}</p>
-          <Slideshow />
+        <Slideshow v-if="!mdAndDown" />
       </div>
     </video-background>
   </section>
@@ -18,6 +18,7 @@
 import VideoBackground from "vue-responsive-video-background-player";
 import backgroundVideo from "../assets/Video/A Certain Ratio.mp4";
 import Slideshow from "../components/Slideshow.vue";
+import { useDisplay } from "vuetify";
 
 const { tagline } = defineProps({
   tagline: {
@@ -25,6 +26,8 @@ const { tagline } = defineProps({
     default: "",
   },
 });
+
+const { mdAndDown } = useDisplay();
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- make sidebar navigation responsive with mobile toolbar and toggle
- style updates for mobile view
- hide homepage slideshow on small screens
- stack About page content on mobile

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a30664efe883278274cc835121a04f