### PR TITLE
Center home page title on mobile

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -66,6 +66,13 @@ const { mdAndDown } = useDisplay();
   position: absolute;
   left: 40%;
 }
+
+@media (max-width: 600px) {
+  .title {
+    left: 50%;
+    transform: translateX(-50%);
+  }
+}
 .overlay {
   position: absolute;
   top: 0;


### PR DESCRIPTION
## Summary
- center the home page title on mobile with responsive CSS

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a30ba047c88327ad3bcef3e2ef3335