### PR TITLE
Add dynamic gallery folder pages and navigation

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -9,6 +9,16 @@ const isHome = computed(() => route.path === '/')
 const { mdAndDown } = useDisplay()
 const drawer = ref(!mdAndDown.value)
 watch(mdAndDown, val => { drawer.value = !val })
+
+const modules = import.meta.glob('../assets/Gallery/*/*.jpg')
+const galleryFolders = Array.from(
+  new Set(
+    Object.keys(modules).map(path => {
+      const parts = path.split('/')
+      return parts[parts.length - 2]
+    })
+  )
+).sort()
 </script>
 
 <template>
@@ -35,7 +45,18 @@ watch(mdAndDown, val => { drawer.value = !val })
       <v-list-item title="Andrew Jenkin Sculpture" class="text-h3" style="font-size: 1.2rem;"></v-list-item>
       <v-list-item to="/" title="Home"></v-list-item>
       <v-list-item to="/about" title="About"></v-list-item>
-      <v-list-item to="/gallery" title="Gallery"></v-list-item>
+      <v-list-group>
+        <template #activator="{ props }">
+          <v-list-item v-bind="props" title="Gallery"></v-list-item>
+        </template>
+        <v-list-item to="/gallery" title="All"></v-list-item>
+        <v-list-item
+          v-for="folder in galleryFolders"
+          :key="folder"
+          :to="`/gallery/${encodeURIComponent(folder)}`"
+          :title="folder"
+        ></v-list-item>
+      </v-list-group>
       <v-list-item to="/social" title="Social"></v-list-item>
       <v-list-item to="/contact" title="Contact"></v-list-item>
       <v-list-item to="/projects" title="Projects"></v-list-item>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -3,6 +3,7 @@ import { createRouter, createWebHistory } from 'vue-router'
 import Home from '../views/Home.vue'
 import About from '../views/About.vue'
 import Gallery from '../views/Gallery.vue'
+import GalleryFolder from '../views/GalleryFolder.vue'
 import Social from '../views/Social.vue'
 import Contact from '../views/Contact.vue'
 import Projects from '../views/Projects.vue'
@@ -11,6 +12,12 @@ const routes = [
   { path: '/', name: 'home', component: Home },
   { path: '/about', name: 'about', component: About },
   { path: '/gallery', name: 'gallery', component: Gallery },
+  {
+    path: '/gallery/:folder',
+    name: 'gallery-folder',
+    component: GalleryFolder,
+    props: true,
+  },
   { path: '/social', name: 'social', component: Social },
   { path: '/contact', name: 'contact', component: Contact },
   { path: '/projects', name: 'projects', component: Projects },

--- a/src/views/GalleryFolder.vue
+++ b/src/views/GalleryFolder.vue
@@ -1,0 +1,103 @@
+<template>
+  <div class="page container fade-up">
+    <h1>{{ folder }}</h1>
+    <div class="gallery-grid">
+      <div
+        v-for="(image, index) in images"
+        :key="index"
+        class="gallery-item"
+      >
+        <img :src="image.src" :alt="image.alt" />
+        <div class="overlay">
+          <span>{{ image.caption }}</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+const props = defineProps({
+  folder: {
+    type: String,
+    required: true,
+  },
+})
+
+const modules = import.meta.glob("../assets/Gallery/*/*.jpg", {
+  eager: true,
+  import: "default",
+})
+
+const images = computed(() => {
+  const list = []
+  for (const [path, src] of Object.entries(modules)) {
+    if (path.includes(`/Gallery/${props.folder}/`)) {
+      const parts = path.split('/')
+      const file = parts[parts.length - 1]
+      const caption = file.replace(/\.[^/.]+$/, '')
+      list.push({ src, alt: caption, caption })
+    }
+  }
+  return list
+})
+</script>
+
+<style scoped>
+.page {
+  padding: 1rem;
+  font-family: "Playfair Display", serif;
+  font-optical-sizing: auto;
+  font-weight: <weight>;
+  font-style: normal;
+}
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1rem;
+  font-family: "Playfair Display", serif;
+  font-optical-sizing: auto;
+  font-weight: <weight>;
+  font-style: normal;
+}
+
+.gallery-item {
+  position: relative;
+  overflow: hidden;
+  font-family: "Playfair Display", serif;
+  font-optical-sizing: auto;
+  font-weight: <weight>;
+  font-style: normal;
+}
+
+.gallery-item img {
+  width: 100%;
+  display: block;
+  font-family: "Playfair Display", serif;
+  font-optical-sizing: auto;
+  font-weight: <weight>;
+  font-style: normal;
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  font-family: "Playfair Display", serif;
+  font-optical-sizing: auto;
+  font-weight: <weight>;
+  font-style: normal;
+}
+
+.gallery-item:hover .overlay {
+  opacity: 1;
+}
+</style>


### PR DESCRIPTION
## Summary
- add gallery folder view to render images for a specific folder
- extend router to handle `/gallery/:folder` paths
- show gallery folders in sidebar navigation under Gallery

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5dc33644c83279fe6c43ad2c25345