### PR TITLE
Add dynamic gallery folder pages and navigation

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -9,6 +9,16 @@ const isHome = computed(() => route.path === '/')
 const { mdAndDown } = useDisplay()
 const drawer = ref(!mdAndDown.value)
 watch(mdAndDown, val => { drawer.value = !val })
+
+const modules = import.meta.glob('../assets/Gallery/*/*.jpg')
+const galleryFolders = Array.from(
+  new Set(
+    Object.keys(modules).map(path => {
+      const parts = path.split('/')
+      return parts[parts.length - 2]
+    })
+  )
+).sort()
 </script>
 
 <template>
@@ -35,7 +45,18 @@ watch(mdAndDown, val => { drawer.value = !val })
       <v-list-item title="Andrew Jenkin Sculpture" class="text-h3" style="font-size: 1.2rem;"></v-list-item>
       <v-list-item to="/" title="Home"></v-list-item>
       <v-list-item to="/about" title="About"></v-list-item>
-      <v-list-item to="/gallery" title="Gallery"></v-list-item>
+      <v-list-group>
+        <template #activator="{ props }">
+          <v-list-item v-bind="props" title="Gallery"></v-list-item>
+        </template>
+        <v-list-item to="/gallery" title="All"></v-list-item>
+        <v-list-item
+          v-for="folder in galleryFolders"
+          :key="folder"
+          :to="`/gallery/${encodeURIComponent(folder)}`"
+          :title="folder"
+        ></v-list-item>
+      </v-list-group>
       <v-list-item to="/social" title="Social"></v-list-item>
       <v-list-item to="/contact" title="Contact"></v-list-item>
       <v-list-item to="/projects" title="Projects"></v-list-item>
@@ -53,7 +74,6 @@ font-size: 1.2rem;
   font-weight: 300;
   font-family: "Playfair Display", serif;
   font-optical-sizing: auto;
-  font-weight: <weight>;
   font-style: normal;
 }
 
@@ -85,7 +105,6 @@ font-size: 1.2rem;
   background: transparent;
   font-family: "Playfair Display", serif;
   font-optical-sizing: auto;
-  font-weight: <weight>;
   font-style: normal;
 }
 
@@ -93,7 +112,6 @@ font-size: 1.2rem;
   background-color: rgba(0, 0, 0, 0.04);
   font-family: "Playfair Display", serif;
   font-optical-sizing: auto;
-  font-weight: <weight>;
   font-style: normal;
 }
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -3,6 +3,7 @@ import { createRouter, createWebHistory } from 'vue-router'
 import Home from '../views/Home.vue'
 import About from '../views/About.vue'
 import Gallery from '../views/Gallery.vue'
+import GalleryFolder from '../views/GalleryFolder.vue'
 import Social from '../views/Social.vue'
 import Contact from '../views/Contact.vue'
 import Projects from '../views/Projects.vue'
@@ -11,6 +12,12 @@ const routes = [
   { path: '/', name: 'home', component: Home },
   { path: '/about', name: 'about', component: About },
   { path: '/gallery', name: 'gallery', component: Gallery },
+  {
+    path: '/gallery/:folder',
+    name: 'gallery-folder',
+    component: GalleryFolder,
+    props: true,
+  },
   { path: '/social', name: 'social', component: Social },
   { path: '/contact', name: 'contact', component: Contact },
   { path: '/projects', name: 'projects', component: Projects },

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -32,7 +32,7 @@ import aboutPic from '../assets/About/AboutPic.jpg'
   padding: 1rem 2rem 1rem 2rem;
   font-family: "Playfair Display", serif;
   font-optical-sizing: auto;
-  font-weight: <weight>;
+  font-weight: 400;
   font-style: normal;
 }
 

--- a/src/views/Contact.vue
+++ b/src/views/Contact.vue
@@ -24,7 +24,7 @@
   padding: 1rem;
   font-family: "Playfair Display", serif;
   font-optical-sizing: auto;
-  font-weight: <weight>;
+  font-weight: 400;
   font-style: normal;
 }
 
@@ -34,7 +34,7 @@
   gap: 1rem;
   font-family: "Playfair Display", serif;
   font-optical-sizing: auto;
-  font-weight: <weight>;
+  font-weight: 400;
   font-style: normal;
 }
 

--- a/src/views/Gallery.vue
+++ b/src/views/Gallery.vue
@@ -44,7 +44,7 @@ for (const [path, src] of Object.entries(modules)) {
   padding: 1rem;
   font-family: "Playfair Display", serif;
   font-optical-sizing: auto;
-  font-weight: <weight>;
+  font-weight: 400;
   font-style: normal;
 }
 
@@ -52,7 +52,7 @@ for (const [path, src] of Object.entries(modules)) {
   margin-bottom: 2rem;
   font-family: "Playfair Display", serif;
   font-optical-sizing: auto;
-  font-weight: <weight>;
+  font-weight: 400;
   font-style: normal;
 }
 
@@ -60,7 +60,7 @@ for (const [path, src] of Object.entries(modules)) {
   margin-bottom: 1rem;
   font-family: "Playfair Display", serif;
   font-optical-sizing: auto;
-  font-weight: <weight>;
+  font-weight: 400;
   font-style: normal;
 }
 
@@ -70,7 +70,7 @@ for (const [path, src] of Object.entries(modules)) {
   gap: 1rem;
   font-family: "Playfair Display", serif;
   font-optical-sizing: auto;
-  font-weight: <weight>;
+  font-weight: 400;
   font-style: normal;
 }
 
@@ -79,7 +79,7 @@ for (const [path, src] of Object.entries(modules)) {
   overflow: hidden;
   font-family: "Playfair Display", serif;
   font-optical-sizing: auto;
-  font-weight: <weight>;
+  font-weight: 400;
   font-style: normal;
 }
 
@@ -88,7 +88,7 @@ for (const [path, src] of Object.entries(modules)) {
   display: block;
   font-family: "Playfair Display", serif;
   font-optical-sizing: auto;
-  font-weight: <weight>;
+  font-weight: 400;
   font-style: normal;
 }
 
@@ -104,7 +104,7 @@ for (const [path, src] of Object.entries(modules)) {
   transition: opacity 0.3s ease;
   font-family: "Playfair Display", serif;
   font-optical-sizing: auto;
-  font-weight: <weight>;
+  font-weight: 400;
   font-style: normal;
 }
 

--- a/src/views/GalleryFolder.vue
+++ b/src/views/GalleryFolder.vue
@@ -1,0 +1,135 @@
+<template>
+  <div class="page container fade-up">
+    <h1>{{ folder }}</h1>
+    <div class="gallery-grid">
+      <div
+        v-for="(image, index) in images"
+        :key="index"
+        class="gallery-item"
+        :class="{ 'crazy-frame': folder === 'Crazy Frames' }"
+      >
+        <img :src="image.src" :alt="image.alt" />
+        <div class="overlay">
+          <span>{{ image.caption }}</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted } from 'vue'
+const props = defineProps({
+  folder: {
+    type: String,
+    required: true,
+  },
+})
+
+const modules = import.meta.glob("../assets/Gallery/*/*.jpg", {
+  eager: true,
+  import: "default",
+})
+
+const images = computed(() => {
+  const list = []
+  for (const [path, src] of Object.entries(modules)) {
+    if (path.includes(`/Gallery/${props.folder}/`)) {
+      const parts = path.split('/')
+      const file = parts[parts.length - 1]
+      const caption = file.replace(/\.[^/.]+$/, '')
+      list.push({ src, alt: caption, caption })
+    }
+  }
+  return list
+})
+
+const maxRotationDegreesX = 60
+const maxRotationDegreesY = 60
+const perspectivePx = 600
+
+onMounted(() => {
+  if (props.folder === 'Crazy Frames') {
+    const items = document.querySelectorAll('.crazy-frame')
+    items.forEach(item => {
+      const img = item.querySelector('img')
+      item.addEventListener('mousemove', event => {
+        const rect = item.getBoundingClientRect()
+        const x = event.clientX - rect.left - rect.width / 2
+        const y = event.clientY - rect.top - rect.height / 2
+        const rotationY = (x * maxRotationDegreesX) / (rect.width / 2)
+        const rotationX = (-y * maxRotationDegreesY) / (rect.height / 2)
+        const transform = `perspective(${perspectivePx}px) rotate3d(1, 0, 0, ${rotationX}deg) rotate3d(0, 1, 0, ${rotationY}deg)`
+        img.style.transform = transform
+      })
+      item.addEventListener('mouseleave', () => {
+        img.style.transform = `perspective(${perspectivePx}px)`
+      })
+    })
+  }
+})
+</script>
+
+<style scoped>
+.page {
+  padding: 1rem;
+  font-family: "Playfair Display", serif;
+  font-optical-sizing: auto;
+  font-weight: 400;
+  font-style: normal;
+}
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1rem;
+  font-family: "Playfair Display", serif;
+  font-optical-sizing: auto;
+  font-weight: 400;
+  font-style: normal;
+}
+
+.gallery-item {
+  position: relative;
+  overflow: hidden;
+  font-family: "Playfair Display", serif;
+  font-optical-sizing: auto;
+  font-weight: 400;
+  font-style: normal;
+}
+
+.gallery-item img {
+  width: 100%;
+  display: block;
+  font-family: "Playfair Display", serif;
+  font-optical-sizing: auto;
+  font-weight: 400;
+  font-style: normal;
+  transition: transform 0.1s ease-out;
+  transform-style: preserve-3d;
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  font-family: "Playfair Display", serif;
+  font-optical-sizing: auto;
+  font-weight: 400;
+  font-style: normal;
+}
+
+.gallery-item:hover .overlay {
+  opacity: 1;
+}
+
+.crazy-frame {
+  perspective: 600px;
+}
+</style>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -35,7 +35,7 @@ const { mdAndDown } = useDisplay();
   overflow: hidden;
   font-family: "Playfair Display", serif;
   font-optical-sizing: auto;
-  font-weight: <weight>;
+  font-weight: 400;
   font-style: normal;
 }
 .home {
@@ -58,7 +58,7 @@ const { mdAndDown } = useDisplay();
   color: white;
   font-family: "Playfair Display", serif;
   font-optical-sizing: auto;
-  font-weight: <weight>;
+  font-weight: 400;
   font-style: normal;
 }
 
@@ -85,7 +85,7 @@ const { mdAndDown } = useDisplay();
     margin-bottom: 1rem;
     font-family: "Playfair Display", serif;
     font-optical-sizing: auto;
-    font-weight: <weight>;
+    font-weight: 400;
     font-style: normal;
     color: white;
   }

--- a/src/views/Projects.vue
+++ b/src/views/Projects.vue
@@ -43,7 +43,7 @@ const projects = Object.entries(projectMap).map(([title, images]) => ({
   padding: 1rem;
   font-family: "Playfair Display", serif;
   font-optical-sizing: auto;
-  font-weight: <weight>;
+  font-weight: 400;
   font-style: normal;
 }
 
@@ -53,7 +53,7 @@ const projects = Object.entries(projectMap).map(([title, images]) => ({
   gap: 1rem;
   font-family: "Playfair Display", serif;
   font-optical-sizing: auto;
-  font-weight: <weight>;
+  font-weight: 400;
   font-style: normal;
 }
 
@@ -64,7 +64,7 @@ const projects = Object.entries(projectMap).map(([title, images]) => ({
   transition: transform 0.3s ease, box-shadow 0.3s ease;
   font-family: "Playfair Display", serif;
   font-optical-sizing: auto;
-  font-weight: <weight>;
+  font-weight: 400;
   font-style: normal;
 }
 
@@ -75,7 +75,7 @@ const projects = Object.entries(projectMap).map(([title, images]) => ({
   margin-bottom: 0.5rem;
   font-family: "Playfair Display", serif;
   font-optical-sizing: auto;
-  font-weight: <weight>;
+  font-weight: 400;
   font-style: normal;
 }
 
@@ -84,7 +84,7 @@ const projects = Object.entries(projectMap).map(([title, images]) => ({
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
   font-family: "Playfair Display", serif;
   font-optical-sizing: auto;
-  font-weight: <weight>;
+  font-weight: 400;
   font-style: normal;
 }
 </style>

--- a/src/views/Social.vue
+++ b/src/views/Social.vue
@@ -10,7 +10,7 @@
   padding: 1rem;
   font-family: "Playfair Display", serif;
   font-optical-sizing: auto;
-  font-weight: <weight>;
+  font-weight: 400;
   font-style: normal;
 }
 </style>


### PR DESCRIPTION
## Summary
- add gallery folder view to render images for a specific folder
- extend router to handle `/gallery/:folder` paths
- show gallery folders in sidebar navigation under Gallery
- apply mouse-driven 3D tilt effect for Crazy Frames images
- replace placeholder font-weight declarations with numeric values

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5dc33644c83279fe6c43ad2c25345