### PR TITLE
Add 3D Gallery page with Gaussian splat viewer

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -57,6 +57,7 @@ const galleryFolders = Array.from(
           :title="folder"
         ></v-list-item>
       </v-list-group>
+      <v-list-item to="/3d-gallery" title="3D Gallery"></v-list-item>
       <v-list-item to="/social" title="Social"></v-list-item>
       <v-list-item to="/contact" title="Contact"></v-list-item>
       <v-list-item to="/projects" title="Projects"></v-list-item>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -7,6 +7,7 @@ import GalleryFolder from '../views/GalleryFolder.vue'
 import Social from '../views/Social.vue'
 import Contact from '../views/Contact.vue'
 import Projects from '../views/Projects.vue'
+import ThreeDGallery from '../views/ThreeDGallery.vue'
 
 const routes = [
   { path: '/', name: 'home', component: Home },
@@ -18,6 +19,7 @@ const routes = [
     component: GalleryFolder,
     props: true,
   },
+  { path: '/3d-gallery', name: '3d-gallery', component: ThreeDGallery },
   { path: '/social', name: 'social', component: Social },
   { path: '/contact', name: 'contact', component: Contact },
   { path: '/projects', name: 'projects', component: Projects },

--- a/src/views/ThreeDGallery.vue
+++ b/src/views/ThreeDGallery.vue
@@ -1,0 +1,44 @@
+<template>
+  <section class="three-d-gallery">
+    <h1>3D Gallery</h1>
+    <script type="importmap">
+      {
+        "imports": {
+          "playcanvas": "https://cdn.jsdelivr.net/npm/playcanvas@latest/build/playcanvas.mjs"
+        }
+      }
+    </script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@playcanvas/web-components@latest/dist/pwc.mjs"></script>
+    <pc-app antialias="false" depth="false" high-resolution="false" stencil="false">
+      <pc-asset id="splat" :src="splat"></pc-asset>
+      <pc-asset src="https://cdn.jsdelivr.net/npm/playcanvas@latest/scripts/esm/camera-controls.mjs"></pc-asset>
+      <pc-scene>
+        <pc-entity name="camera" position="0 0 3">
+          <pc-camera></pc-camera>
+          <pc-scripts>
+            <pc-script name="cameraControls"></pc-script>
+          </pc-scripts>
+        </pc-entity>
+        <pc-entity name="model">
+          <pc-splat asset="splat"></pc-splat>
+        </pc-entity>
+      </pc-scene>
+    </pc-app>
+  </section>
+</template>
+
+<script setup>
+import splat from '../assets/Splatter/scan.ply?url'
+</script>
+
+<style scoped>
+.three-d-gallery {
+  width: 100%;
+  height: 100%;
+}
+pc-app {
+  width: 100%;
+  height: 80vh;
+  display: block;
+}
+</style>

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,5 +4,14 @@ import vuetify from 'vite-plugin-vuetify'
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [vue(), vuetify({ autoImport: true })],
+  plugins: [
+    vue({
+      template: {
+        compilerOptions: {
+          isCustomElement: tag => tag.startsWith('pc-'),
+        },
+      },
+    }),
+    vuetify({ autoImport: true }),
+  ],
 })


### PR DESCRIPTION
## Summary
- add `/3d-gallery` route and link in sidebar
- render local `scan.ply` Gaussian splat via PlayCanvas web components
- allow `pc-*` custom elements in Vite configuration

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a84ef307348327a9938475e713f8dc