### PR TITLE
Fix PlayCanvas 3D gallery initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,13 @@
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400..900;1,400..900&display=swap" rel="stylesheet">
     <script src="https://kit.fontawesome.com/ea2ef694b6.js" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
+    <script type="importmap">
+      {
+        "imports": {
+          "playcanvas": "https://cdn.jsdelivr.net/npm/playcanvas@latest/build/playcanvas.mjs"
+        }
+      }
+    </script>
   </head>
   <body>
     <div id="app"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@mdi/font": "^7.4.47",
+        "@playcanvas/web-components": "^0.2.8",
         "@spz-loader/playcanvas": "^0.3.0",
         "playcanvas": "^2.10.6",
         "vue": "^3.5.18",
@@ -495,6 +496,12 @@
       "resolved": "https://registry.npmjs.org/@mdi/font/-/font-7.4.47.tgz",
       "integrity": "sha512-43MtGpd585SNzHZPcYowu/84Vz2a2g31TvPMTm9uTiCSWzaheQySUcSyUH/46fPnuPQWof2yd0pGBtzee/IQWw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@playcanvas/web-components": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@playcanvas/web-components/-/web-components-0.2.8.tgz",
+      "integrity": "sha512-DvWkFNKv4wum5N2zxmJOcJCexJU39wbbtwGeGxF/EU/Cqf1Yco9MLq7un9WqXxgpSTQK9EK/HMfYxGaRMWEeTw==",
+      "license": "MIT"
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.29",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@mdi/font": "^7.4.47",
+    "@playcanvas/web-components": "^0.2.8",
     "@spz-loader/playcanvas": "^0.3.0",
     "playcanvas": "^2.10.6",
     "vue": "^3.5.18",

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,7 @@ import './style.css'
 import 'vuetify/styles'
 import { createVuetify } from 'vuetify'
 import '@mdi/font/css/materialdesignicons.css'
+import '@playcanvas/web-components/dist/pwc.mjs'
 
 const app = createApp(App)
 const vuetify = createVuetify()

--- a/src/views/ThreeDGallery.vue
+++ b/src/views/ThreeDGallery.vue
@@ -1,15 +1,6 @@
 <template>
   <section class="three-d-gallery">
     <h1>3D Gallery</h1>
-    <canvas ref="canvas"></canvas>
-    <script type="importmap">
-      {
-        "imports": {
-          "playcanvas": "https://cdn.jsdelivr.net/npm/playcanvas@latest/build/playcanvas.mjs"
-        }
-      }
-    </script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@playcanvas/web-components@latest/dist/pwc.mjs"></script>
     <pc-app antialias="false" depth="false" high-resolution="false" stencil="false">
       <pc-asset id="splat" :src="splat"></pc-asset>
       <pc-asset src="https://cdn.jsdelivr.net/npm/playcanvas@latest/scripts/esm/camera-controls.mjs"></pc-asset>
@@ -29,37 +20,15 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
-import { Application, Entity, Color } from 'playcanvas'
-import { createGSplatEntityFromSpzUrlAsync } from '@spz-loader/playcanvas'
 import splatUrl from '../assets/Splatter/scan.spz?url'
 
-const canvas = ref(null)
-
-onMounted(async () => {
-  const app = new Application(canvas.value, {
-    graphicsDeviceOptions: { antialias: true }
-  })
-  app.start()
-
-  const camera = new Entity('camera')
-  camera.addComponent('camera', {
-    clearColor: new Color(0.1, 0.1, 0.1)
-  })
-  camera.setPosition(0, 0, 3)
-  app.root.addChild(camera)
-
-  const spzEntity = await createGSplatEntityFromSpzUrlAsync(splatUrl)
-  app.root.addChild(spzEntity)
-})
+const splat = splatUrl
 </script>
 
 <style scoped>
 .three-d-gallery {
   width: 100%;
   height: 100%;
-}
-canvas {
 }
 pc-app {
   width: 100%;

--- a/vite.config.js
+++ b/vite.config.js
@@ -14,4 +14,5 @@ export default defineConfig({
     }),
     vuetify({ autoImport: true }),
   ],
+  assetsInclude: ['**/*.spz'],
 })


### PR DESCRIPTION
## Summary
- Load PlayCanvas web components globally and define import map
- Simplify 3D Gallery to use `<pc-app>` and bind Gaussian splat asset
- Ensure Vite bundles `.spz` assets

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `find dist -name '*.spz'`

------
https://chatgpt.com/codex/tasks/task_e_68a858a2a8708327a7783b93571cb67a