### PR TITLE
Embed 8th Wall model viewer

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,6 @@ import './style.css'
 import 'vuetify/styles'
 import { createVuetify } from 'vuetify'
 import '@mdi/font/css/materialdesignicons.css'
-import '@playcanvas/web-components/dist/pwc.mjs'
 
 const app = createApp(App)
 const vuetify = createVuetify()

--- a/src/views/ThreeDGallery.vue
+++ b/src/views/ThreeDGallery.vue
@@ -6,34 +6,16 @@
         {{ file.label }}
       </option>
     </select>
-    <div v-if="loading">Loading splat...</div>
-    <div v-else-if="error">{{ error }}</div>
-    <pc-app
-      v-else
-      antialias="false"
-      depth="false"
-      high-resolution="false"
-      stencil="false"
-    >
-      <pc-asset id="splat" :src="splat"></pc-asset>
-      <pc-asset src="https://cdn.jsdelivr.net/npm/playcanvas@latest/scripts/esm/camera-controls.mjs"></pc-asset>
-      <pc-scene>
-        <pc-entity name="camera" position="0 0 3">
-          <pc-camera></pc-camera>
-          <pc-scripts>
-            <pc-script name="cameraControls"></pc-script>
-          </pc-scripts>
-        </pc-entity>
-        <pc-entity name="model">
-          <pc-splat asset="splat"></pc-splat>
-        </pc-entity>
-      </pc-scene>
-    </pc-app>
+    <iframe
+      class="model-viewer"
+      :src="viewerUrl"
+      allow="camera; microphone; xr-spatial-tracking"
+    ></iframe>
   </section>
 </template>
 
 <script setup>
-import { ref, watch, onMounted } from 'vue'
+import { ref, computed } from 'vue'
 
 const splatFiles = [
   {
@@ -47,27 +29,12 @@ const splatFiles = [
 ]
 
 const currentFile = ref(splatFiles[0].value)
-const splat = ref('')
-const loading = ref(false)
-const error = ref('')
-
-const loadSplat = async () => {
-  loading.value = true
-  error.value = ''
-  try {
-    const res = await fetch(currentFile.value)
-    if (!res.ok) throw new Error('Failed to load')
-    splat.value = currentFile.value
-  } catch (e) {
-    error.value = 'Failed to load selected splat.'
-    splat.value = ''
-  } finally {
-    loading.value = false
-  }
-}
-
-watch(currentFile, loadSplat)
-onMounted(loadSplat)
+const viewerUrl = computed(
+  () =>
+    `https://scaniverse.8thwall.app/model-viewer/?model=${encodeURIComponent(
+      currentFile.value,
+    )}`,
+)
 </script>
 
 <style scoped>
@@ -75,9 +42,9 @@ onMounted(loadSplat)
   width: 100%;
   height: 100%;
 }
-pc-app {
+.model-viewer {
   width: 100%;
   height: 80vh;
-  display: block;
+  border: none;
 }
 </style>


### PR DESCRIPTION
## Summary
- replace custom PlayCanvas viewer with 8th Wall model-viewer for splat files
- remove unused PlayCanvas web components import

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a8602d8bf88327a06b26e7d4e6344e