### PR TITLE
Add CORS headers for Splatter assets

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,3 +6,9 @@
   from = "/*"
   to = "/index.html"
   status = 200
+
+[[headers]]
+  for = "/assets/Splatter/*.spz"
+  [headers.values]
+    Access-Control-Allow-Origin = "*"
+    Content-Type = "application/octet-stream"


### PR DESCRIPTION
## Summary
- add Netlify headers for Splatter .spz files to enable CORS

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a865f161b08327a67d89de01c305af