### PR TITLE
Use absolute Splatter model URL in 3D gallery

### DIFF
--- a/src/views/ThreeDGallery.vue
+++ b/src/views/ThreeDGallery.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script setup>
-const modelUrl = '/assets/Splatter/scan.spz'
+const modelUrl = new URL('/assets/Splatter/scan.spz', window.location.origin).href;
 const viewerUrl = `https://scaniverse.8thwall.app/model-viewer/?model=${encodeURIComponent(
   modelUrl
 )}`


### PR DESCRIPTION
## Summary
- Build Splatter model URL from window origin for consistent loading
- Ensure iframe viewer encodes updated model URL

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a86def515c83278b646c6e4ffcbcad