### PR TITLE
feat: load 3d model via postmessage

### DIFF
--- a/src/views/ThreeDGallery.vue
+++ b/src/views/ThreeDGallery.vue
@@ -2,6 +2,7 @@
   <section class="three-d-gallery">
     <h1>3D Gallery</h1>
     <iframe
+      ref="viewerFrame"
       class="model-viewer"
       :src="viewerUrl"
       allow="camera; microphone; xr-spatial-tracking"
@@ -10,10 +11,22 @@
 </template>
 
 <script setup>
+import { ref, onMounted } from 'vue';
+
+const viewerFrame = ref(null);
 const modelUrl = new URL('/assets/Splatter/scan.spz', window.location.origin).href;
-const viewerUrl = `https://scaniverse.8thwall.app/model-viewer/?model=${encodeURIComponent(
-  modelUrl
-)}`
+const viewerUrl = 'https://scaniverse.8thwall.app/model-viewer/';
+
+onMounted(() => {
+  const frame = viewerFrame.value;
+  if (!frame) return;
+  frame.addEventListener('load', () => {
+    frame.contentWindow?.postMessage(
+      { action: 'loadModel', url: modelUrl },
+      'https://scaniverse.8thwall.app'
+    );
+  });
+});
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- load scan.spz into 8thWall viewer via cross-window messaging

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acd16659d883279fb4f08b2c090a02