### PR TITLE
Add social media links to sidebar

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -59,6 +59,35 @@ const galleryFolders = Array.from(
       </v-list-group>
       <v-list-item to="/social" title="Social"></v-list-item>
       <v-list-item to="/contact" title="Contact"></v-list-item>
+      <div class="social-links">
+        <a
+          href="https://facebook.com"
+          target="_blank"
+          rel="noopener"
+        >
+          <v-btn icon>
+            <i class="fab fa-facebook-f"></i>
+          </v-btn>
+        </a>
+        <a
+          href="https://linkedin.com"
+          target="_blank"
+          rel="noopener"
+        >
+          <v-btn icon>
+            <i class="fab fa-linkedin-in"></i>
+          </v-btn>
+        </a>
+        <a
+          href="https://instagram.com"
+          target="_blank"
+          rel="noopener"
+        >
+          <v-btn icon>
+            <i class="fab fa-instagram"></i>
+          </v-btn>
+        </a>
+      </div>
     </v-list>
   </v-navigation-drawer>
 </template>
@@ -112,6 +141,13 @@ font-size: 1.2rem;
   font-family: "Playfair Display", serif;
   font-optical-sizing: auto;
   font-style: normal;
+}
+
+.social-links {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-top: 1rem;
 }
 
 </style>


### PR DESCRIPTION
## Summary
- add social media icons (Facebook, LinkedIn, Instagram) to sidebar with external links
- style social-links container to display icons horizontally with spacing

## Testing
- `npm test` *(fails: missing script "test"*)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af2eecf3888327a3c1625ef022648a